### PR TITLE
workflows: Add PR deployment action

### DIFF
--- a/.github/workflows/pr-deployment.yml
+++ b/.github/workflows/pr-deployment.yml
@@ -1,0 +1,79 @@
+name: OpenEduHub - PR Deployment
+
+on:
+  pull_request_target:
+
+jobs:
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: ./repo
+      - run: |
+          cd repo
+          REF=$(echo ${{ github.ref }} | sed 's/\//\\\//g')
+          sed -i "s/baseUrl: \/operating-systems\//baseUrl: \/operating-systems\/$REF\//" config.yaml
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: ./repo
+          file: ./repo/Dockerfile
+          push: false
+          load: true
+          tags: operating-systems/docusaurus:latest
+          cache-from: type=gha
+          cache-to: type=gha
+
+      - name: Load Image
+        run: |
+          mkdir -p ${{ github.ref }}
+          docker image list
+          docker run -v $GITHUB_WORKSPACE/repo:/content -v $GITHUB_WORKSPACE/${{ github.ref }}:/output operating-systems/docusaurus:latest
+      # - name: Push to Upstream Repository
+      #   uses: cpina/github-action-push-to-another-repository@main
+      #   env:
+      #     API_TOKEN_GITHUB: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     source-directory: ${{ github.ref }}
+      #     target-directory: ${{ github.ref }}
+      #     destination-github-username: 'open-education-hub'
+      #     destination-repository-name: 'operating-systems'
+      #     user-email: 'github-actions[bot]@users.noreply.github.com'
+      #     target-branch: gh-pages
+
+      # Popular action to deploy to GitHub Pages:
+      # Docs: https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-docusaurus
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Build output to publish to the `gh-pages-pr` branch:
+          publish_dir: ./${{ github.ref }}
+          destination_dir: ${{ github.ref }}
+          # The following lines assign commit authorship to the official
+          # GH-Actions bot for deploys to `gh-pages` branch:
+          # https://github.com/actions/checkout/issues/13#issuecomment-724415212
+          # The GH actions bot is used by default if you didn't specify the two fields.
+          # You can swap them out with your own user credentials.
+          publish_branch: gh-pages
+
+      - name: Add Comment to PR
+        if: github.event_name == 'pull_request'
+        env:
+          URL: ${{ github.event.pull_request.comments_url }}
+          GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+        run: |
+          curl \
+            -X POST \
+            -u $GITHUB_TOKEN \
+            $URL \
+            -H "Content-Type: application/json" \
+            --data '{ "body": "Published at http://open-education-hub.github.io/operating-systems/${{ github.ref }}" }'


### PR DESCRIPTION
The action builds the rendered website and pushes it to the branch `gh-pages` in a directory named after the PR number: `refs/pull/<number>/merge`. It then publishes a message containing the link where the website may be inspected.